### PR TITLE
refactor esphome yaml for latest versions

### DIFF
--- a/anavi-light-controller/esphome-anavi-light-controller/anavi-light-controller.yaml
+++ b/anavi-light-controller/esphome-anavi-light-controller/anavi-light-controller.yaml
@@ -1,7 +1,12 @@
+---
 esphome:
-  name: anavi_light_controller
-  platform: ESP8266
+  name: anavi-light-controller
+
+esp8266:
   board: esp12e
+  restore_from_flash: true
+
+
 
 wifi:
   ssid: "SET-YOUR-WIFI"
@@ -26,6 +31,7 @@ api:
   password: "opensource"
 
 ota:
+  platform: esphome
   password: "opensource"
 
 # Please note that if an I2C sensor module is not attached ESPHome
@@ -55,7 +61,6 @@ sensor:
   - platform: bh1750
     name: "BH1750 Illuminance"
     address: 0x23
-    measurement_time: 69
     update_interval: 5s
 
   - platform: bmp085


### PR DESCRIPTION
In order to get it running with a current ESP Home setup, I needed to make a few changes to the default esphome config.

It will still complain about using a password instead of an API key. But this is something I still have to figure out.